### PR TITLE
Explicit call for seaborn.set to apply the default theme

### DIFF
--- a/graphing/seaborn.py
+++ b/graphing/seaborn.py
@@ -54,6 +54,9 @@ def plotsea(sheet):
     import matplotlib.pyplot as plt
     import seaborn as sns
 
+    # Set the default theme
+    sns.set()
+    
     plt.figure(figsize=(10, 6))
     plt.title('')
     plt.xticks(rotation=15)


### PR DESCRIPTION
Since seaborn is used, an explicit call to `seaborn.set()` is needed in order to apply the default theme. Otherwise the default matplotlib theme will be used.